### PR TITLE
Marketplaces catalog primed data is cleaned up, play 2.3.9 upgrade

### DIFF
--- a/app/controllers/Constants.scala
+++ b/app/controllers/Constants.scala
@@ -56,7 +56,9 @@ object Constants {
   val DEFAULT_ORG_NAME = "org.megam"
   val DEFAULT_DOMAIN_NAME = "megam.co"
 
-  
+  val VERSION = "0.8"
+
+
 
   /*Look for a file /var/lib/megam/.megam_auth with fields
   megam@mypaas.io:<randomlygenerated pw>

--- a/app/models/MarketPlaces.scala
+++ b/app/models/MarketPlaces.scala
@@ -30,6 +30,8 @@ import controllers.funnel.FunnelErrors._
 import models._
 import models.riak._
 import models.cache._
+import models.utils._
+
 import com.stackmob.scaliak._
 import com.basho.riak.client.core.query.indexes.{ RiakIndexes, StringBinIndex, LongIntIndex }
 import com.basho.riak.client.core.util.{ Constants => RiakConstants }
@@ -92,30 +94,7 @@ case class MarketPlaceInput(name: String, catalog: MarketPlaceCatalog, plans: mo
 //init the default market place addons
 object MarketPlaceInput {
 
-  val ACTIVE  = "ACTIVE"
-
-  val APP     = "APP"
-  val SERVICE = "SERVICE"
-  val DEW     = "DEW"
-
-
-   val toMap = Map[String, MarketPlaceInput](
-"1-Ubuntu" -> MarketPlaceInput("1-Ubuntu", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/ubuntu.png", "Dew", "Ubuntu Server"), MarketPlacePlans(List(new MarketPlacePlan("0", "Ubuntu 12.04 LTS (Precise Pangolin) is the Ubuntu's sixteenth release and its fourth Long Term Support (LTS) release.", "Free", "12.04", "", "Ubuntu 12.04 +"), new MarketPlacePlan("0", "Shuttleworth indicated that the focus in this development cycle would be a release characterized by 'performance, refinement, maintainability, technical debt' and encouraged the developers to make conservative choices.", "Free", "14.04", "", "Ubuntu 14.04 +"))), DEW, "ubuntu", ACTIVE),
-"2-CoreOS" -> MarketPlaceInput("2-CoreOS", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/coreos.png", "Dew", "CoreOS"), MarketPlacePlans(List(new MarketPlacePlan("0", "CoreOS provides no package manager as a way for the distribution of applications, requiring instead all applications to run inside their containers.", "Free", "633.1.0", "", "CoreOS 633.1.0"))), DEW, "coreos", ACTIVE),
-"3-Debian" -> MarketPlaceInput("3-Debian", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/debian.png", "Dew", "Debian"), MarketPlacePlans(List(new MarketPlacePlan("0", "Debian wheezy.", "Free", "7", "", "Debian wheezy"), new MarketPlacePlan("0", "Debian Jessie.", "Free", "8", "", "Debian Jessie"))), DEW, "debian", ACTIVE),
-"4-CentOS" -> MarketPlaceInput("4-CentOS", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/centos.png", "Dew", "CentOS"), MarketPlacePlans(List(new MarketPlacePlan("0", "CentOS is an Enterprise-class Linux Distribution derived from sources freely provided to the public by Red Hat.", "Free", "7", "", "CentOS 7"))), DEW, "centos", ACTIVE),
-"5-Java" -> MarketPlaceInput("5-Java", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/java.png", "Starter packs", "Java Web Starter"), MarketPlacePlans(List(new MarketPlacePlan("0", "Quickly get started with J2EE Spring framework app and a light-weight database.", "Free", "0.5", "", "Ubuntu 14.04 +"))), APP, "java", ACTIVE),
-"6-Rails" -> MarketPlaceInput("6-Rails", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/rails.png", "Starter packs", "Rails App"), MarketPlacePlans(List(new MarketPlacePlan("0", "Quickly get started with rails app and a light-weight database.", "Free", "0.5", "", "Ubuntu 14.04 +"))), APP, "rails", ACTIVE),
-"7-Play" -> MarketPlaceInput("7-Play", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/play.png", "Starter packs", "RESTful API Server"), MarketPlacePlans(List(new MarketPlacePlan("0", "Build robust RESTful API server using NoSQL(Riak).", "Free", "0.5", "", "Ubuntu 14.04 +"))), APP, "play", ACTIVE),
-"8-Nodejs" -> MarketPlaceInput("8-Nodejs", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/nodejs.png", "Starter packs", "Realtime App"), MarketPlacePlans(List(new MarketPlacePlan("0", "Build fast, scalable, and incredibly efficient blogging platform with light weight database.", "Free", "0.5", "", "Ubuntu 14.04 +"))), APP, "nodejs", ACTIVE),
-"9-Docker" -> MarketPlaceInput("9-Docker", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/docker.png", "Platform", "Container"), MarketPlacePlans(List(new MarketPlacePlan("0", "Docker that automates the deployment of applications inside software containers.", "Free", "0.5", "", "Ubuntu 14.04 +"))), "false", "docker", ACTIVE),
-"10-PostgreSQL" -> MarketPlaceInput("10-PostgreSQL", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/postgres.png", "App Boilers", "Object Relational DBMS"), MarketPlacePlans(List(new MarketPlacePlan("0", "PostgreSQL is a powerful, open source object-relational database system.", "Free", "9.3", "", "Ubuntu 14.04 +"))), SERVICE, "postgresql", ACTIVE),
-"11-Riak" -> MarketPlaceInput("11-Riak", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/riak.png", "App Boilers", "Scalable Distributed Database"),
-MarketPlacePlans(List(new MarketPlacePlan("0", "Riak is a distributed database designed to deliver maximum data availability by distributing data across multiple servers.", "Free", "2.1.0", "http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.0.5/ubuntu/trusty/riak_2.0.5-1_amd64.deb", "Ubuntu 14.04 +"))), SERVICE, "riak", ACTIVE),
-"12-Redis" -> MarketPlaceInput("12-Redis", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/redis.png", "App Boilers", "Key Value Store"), MarketPlacePlans(List(new MarketPlacePlan("0", "Redis is a key-value store which acts as a data structure server with keys containing strings, hashes, lists, sets and sorted sets.", "Free", "2.8.4", "", "Ubuntu 14.04 +"))), SERVICE, "redis", ACTIVE),
-"13-RabbitMQ" -> MarketPlaceInput("13-RabbitMQ", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/rabbitmq.png", "App Boilers", "Message Broker"), MarketPlacePlans(List(new MarketPlacePlan("0", "RabbitMQ is a message broker software  that implements the Advanced Message Queuing Protocol (AMQP).", "Free", "3.3.5", "", "Ubuntu 14.04 +"))), SERVICE, "rabbitmq", ACTIVE),
-"14-Hadoop" -> MarketPlaceInput("14-Hadoop", new MarketPlaceCatalog("https://s3-ap-southeast-1.amazonaws.com/megampub/images/market_place_images/hadoop.png", "Analytics", "Plumbing your big data is easy"), MarketPlacePlans(List(new MarketPlacePlan("0", "Apache Hadoop is a set of algorithms (an open-source software framework) for distributed storage and distributed processing of very large data sets (Big Data) on computer clusters built from commodity hardware", "Free", "2.6.0", "", "Ubuntu 14.04 +"))), SERVICE, "hadoop", ACTIVE)
-)
+  val toMap = MKPData.mkMap
 
   val toStream = toMap.keySet.toStream
 

--- a/app/models/utils/MKPData.scala
+++ b/app/models/utils/MKPData.scala
@@ -1,0 +1,145 @@
+package models.utils
+
+import controllers.Constants
+import models.{MarketPlaceInput, MarketPlacePlans, MarketPlacePlan, MarketPlaceCatalog}
+/**
+-- name: 1-Ubuntu
+   catalog:
+           category: 1-Dew
+           image: ubuntu.png
+           description: Ubuntu Server
+   plan:
+           price: 0 [0$ or charges per month ]
+           description: "Ubuntu 12.04 LTS (Precise Pangolin) is the blah..blah.
+           plantype:
+                  sambar: sambar means megam leverages community stuff
+                  idli  : idli   means megam's as service like scaling, dbaas etc.
+                  dosai : dosai  means somebody else service that can be consumed. (eg: a dns, datadog, newrelic, loggly )
+           version: 14.04
+           source:
+                  OTHERS : link to the
+                  BYOC   : https://github.com/megamsys/nilavu.git
+           os: ubuntu [runs on any operating system or container]
+  cattype: DEW
+  predef : ubuntu
+  status :
+          ACTIVE
+          SOON       - coming soon.
+          TERMINATED - the client filters dead weight.
+**/
+object MKPData {
+
+    private val ACTIVE     = "ACTIVE"
+    private val TERMINATED = "TERMINATED"
+
+    private val APP     = "APP"
+    private val SERVICE = "SERVICE"
+    private val DEW     = "DEW"
+    private val ADDON   = "ADDON"
+
+    private val CATEGORY_DEW        = "1-Dew"
+    private val CATEGORY_BYOC       = "2-BYOC"
+    private val CATEGORY_APPBOILERS = "3-App Boilers"
+    private val CATEGORY_PLATFORM   = "4-Platform"
+    private val CATEGORY_ANALYTICS  = "5-Analytics"
+    private val CATEGORY_UNIKERNEL  = "6-Unikernel"
+
+    private val CATIMAGE_PREFIX     = "https://s3-ap-southeast-1.amazonaws.com/megampub/images/marketplaces/"
+
+    private val SAMBAR = "sambar"
+    private val IDLI   = "idli"
+    private val DOSAI  = "dosai"
+
+    private val CATOS_UBUNTU = "ubuntu"
+    private val FIVE = "5"
+
+
+   private def CatImage(image_file: String): String = CATIMAGE_PREFIX + image_file
+   private def Cat(image: String, category: String, summary: String): MarketPlaceCatalog = new MarketPlaceCatalog(CatImage(image), category,summary)
+   private def Dew(image: String,  summary: String): MarketPlaceCatalog = Cat(image, CATEGORY_DEW, summary)
+   private def BYOC(image: String, summary: String): MarketPlaceCatalog = Cat(image, CATEGORY_BYOC, summary)
+   private def Appb(image: String, summary: String): MarketPlaceCatalog = Cat(image, CATEGORY_APPBOILERS, summary)
+   private def Plat(image: String, summary: String): MarketPlaceCatalog = Cat(image, CATEGORY_PLATFORM, summary)
+   private def BigD(image: String, summary: String): MarketPlaceCatalog = Cat(image, CATEGORY_ANALYTICS, summary)
+
+   private def Plan(price: String, desc: String, plantype: String, version: String, source:  String, os: String): MarketPlacePlan  = MarketPlacePlan(price, desc, plantype, version, source, os)
+   //This can go to an autoupdatable yaml file. So when the server starts it will sync the new marketplace items.
+   private val C1 =  ("1-Ubuntu", Dew("ubuntu.png", "Ubuntu"),
+    List(Plan(FIVE, "Scale out with Ubuntu Server. The leading platform for scale-out computing, Ubuntu Server helps you make the most of your infrastructure.",
+    SAMBAR, "14.04", "http://ubuntu.com", CATOS_UBUNTU)))
+
+   private val C2 =  ("2-CoreOS", Dew("coreos.png", "CoreOS"),
+   List(Plan(FIVE, "CoreOS provides no package manager as a way for the distribution of applications, requiring instead all applications to run inside their containers.",
+     SAMBAR, "633.1.0", "http://coreos.com", "KVM")))
+
+   private val C3 =  ("3-Debian", Dew("debian.png", "Debian"),
+   List(Plan(FIVE, "Debian is a free operating system (OS) for your computer. Wheezy is the codename for 7.0 Debian.",
+   SAMBAR, "7", "http://debian.com", "Debian wheezy"),
+   Plan(FIVE, "Debian is a free operating system (OS) for your computer. Jessie is the codename for 8.0 Debian.",
+   SAMBAR, "8", "http://debian.com", "Debian jessie")))
+
+   private val C4 =  ("4-CentOS", Dew("centos.png", "CentOS"),
+   List(Plan(FIVE, "CentOS is an Enterprise-class Linux Distribution derived from sources freely provided to the public by Red Hat.",
+   SAMBAR, "7", "http://centos.org", "CentOS 7")))
+
+
+   private val C5 =  ("5-Java",   BYOC("java.png", "Java Web starter"),
+   List(Plan(FIVE, "Quickly get started with J2EE Spring framework app.",
+   SAMBAR, Constants.VERSION, "http://oracle.com", CATOS_UBUNTU)))
+
+
+   private val C6 =  ("6-Rails",  BYOC("rails.png", "Rails App"),
+   List(Plan(FIVE, "Quickly get started with rails 4.x app.",
+   SAMBAR, Constants.VERSION, "http://guides.rubyonrails.org/index.html", CATOS_UBUNTU)))
+
+   private val C7 =  ("7-Play",   BYOC("play.png", "Play App"),
+   List(Plan(FIVE, "Build robust RESTful API server using Scala.",
+   SAMBAR, Constants.VERSION, "https://playframework.com/", CATOS_UBUNTU)))
+
+   private val C8 =  ("8-Nodejs", BYOC("nodejs.png", "Realtime App"),
+   List(Plan(FIVE, "Build fast, scalable, and incredibly efficient realtime app in second.",
+   SAMBAR, Constants.VERSION, "https://nodejs.org", CATOS_UBUNTU)))
+
+   private val C9 =  ("9-Docker", Plat("docker.png", "Container"),
+   List(Plan(FIVE, "Docker that automates the deployment of applications inside software containers.",
+   SAMBAR, Constants.VERSION, "https://www.docker.com", "baremetal")))
+
+   private val C10 = ("10-PostgreSQL", Appb("postgres.png", "Object Relational DBMS"),
+   List(Plan(FIVE, "PostgreSQL is a powerful, open source object-relational database system.",
+   SAMBAR, "9.3", "https://postgresql.org", CATOS_UBUNTU)))
+
+   private val C11 = ("11-Riak", Appb("riak.png", "Scalable Distributed Database"),
+   List(Plan(FIVE, "Riak is a distributed database designed to deliver maximum data availability by distributing data across multiple servers.",
+   SAMBAR, "2.1.1", "http://s3.amazonaws.com/downloads.basho.com/riak/2.1/2.1.1/ubuntu/trusty/riak_2.1.1-1_amd64.deb", CATOS_UBUNTU)))
+
+   private val C12 = ("12-Redis", Appb("redis.png", "Key Value Store"),
+   List(Plan(FIVE, "Redis is a key-value store which acts as a data structure server with keys containing strings, hashes, lists, sets and sorted sets.",
+   SAMBAR, "2.8.4", "https://redis.org", CATOS_UBUNTU)))
+
+   private val C13 = ("13-RabbitMQ", Appb("rabbitmq.png", "Message Broker"),
+   List(Plan(FIVE, "RabbitMQ is a message broker software  that implements the Advanced Message Queuing Protocol (AMQP).",
+   SAMBAR, "3.3.5", "https://www.rabbitmq.com", CATOS_UBUNTU)))
+
+   private val C14 = ("14-Hadoop", BigD("hadoop.png", "Plumbing your big data is easy"),
+   List(Plan(FIVE, "Apache Hadoop is a set of algorithms (an open-source software framework) for distributed storage and distributed processing of very large data sets (Big Data) on computer clusters built from commodity hardware",
+   SAMBAR, "2.6.0", "https://hadoop.apache.org/", CATOS_UBUNTU)))
+
+  val mkMap = Map[String, MarketPlaceInput](
+      C1._1  -> MarketPlaceInput(C1._1,  C1._2,  MarketPlacePlans(C1._3),  DEW,     "ubuntu",  ACTIVE),
+      C2._1  -> MarketPlaceInput(C2._1,  C2._2,  MarketPlacePlans(C2._3),  DEW,     "coreos",  ACTIVE),
+      C3._1  -> MarketPlaceInput(C3._1,  C3._2,  MarketPlacePlans(C3._3),  DEW,     "debian",  ACTIVE),
+      C4._1  -> MarketPlaceInput(C4._1,  C4._2,  MarketPlacePlans(C4._3),  DEW,     "centos",  ACTIVE),
+      C5._1  -> MarketPlaceInput(C5._1,  C5._2,  MarketPlacePlans(C5._3),  APP,     "java",    ACTIVE),
+      C6._1  -> MarketPlaceInput(C6._1,  C6._2,  MarketPlacePlans(C6._3),  APP,     "rails",   ACTIVE),
+      C7._1  -> MarketPlaceInput(C7._1,  C7._2,  MarketPlacePlans(C7._3),  APP,     "play",    ACTIVE),
+      C8._1  -> MarketPlaceInput(C8._1,  C8._2,  MarketPlacePlans(C8._3),  APP,     "nodejs",  ACTIVE),
+      C9._1  -> MarketPlaceInput(C9._1,  C9._2,  MarketPlacePlans(C9._3),  ADDON,   "docker",  ACTIVE),
+      C10._1 -> MarketPlaceInput(C10._1, C10._2, MarketPlacePlans(C10._3), SERVICE, "postgresql", ACTIVE),
+      C11._1 -> MarketPlaceInput(C11._1, C11._2, MarketPlacePlans(C11._3), SERVICE, "riak",    ACTIVE),
+      C12._1 -> MarketPlaceInput(C12._1, C12._2, MarketPlacePlans(C12._3), SERVICE, "redis",   ACTIVE),
+      C13._1 -> MarketPlaceInput(C13._1, C13._2, MarketPlacePlans(C13._3), SERVICE, "rabbitmq",ACTIVE),
+      C14._1 -> MarketPlaceInput(C14._1, C14._2, MarketPlacePlans(C14._3), SERVICE, "hadoop",  ACTIVE)
+    )
+
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ resolvers += "JBoss repository" at "https://repository.jboss.org/nexus/content/r
 resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0")
 


### PR DESCRIPTION
The marketplace catalog items has been cleaned up.
1. Here is the reasoning for the fields. Feel free to collaborate on it.

``` yaml
/**
-- name: 1-Ubuntu
   catalog:
           category: 1-Dew
           image: ubuntu.png
           description: Ubuntu Server
   plan:
           price: 0 [0$ or charges per month ]
           description: "Ubuntu 12.04 LTS (Precise Pangolin) is the blah..blah.
           plantype:
                  sambar: sambar means megam leverages community stuff
                  idli  : idli   means megam's as service like scaling, dbaas etc.
                  dosai : dosai  means somebody else service that can be consumed. (eg: a dns, datadog, newrelic, loggly )
           version: 14.04
           source:
                  OTHERS : link to the
                  BYOC   : https://github.com/megamsys/nilavu.git
           os: ubuntu [runs on any operating system or container]
  cattype: DEW
  predef : ubuntu
  status :
          ACTIVE
          SOON       - coming soon.
          TERMINATED - the client filters dead weight.
**/
```
1. The marketplace catalog images are stored under `marketplaces` folder. 
2. Play upgraded to 2.3.9
3. The mkp map gets primed from a new `utils.MKPData` class.
