### PR TITLE
Improved success message with the {ASSMEBLIES_ID}

### DIFF
--- a/app/controllers/Accounts.scala
+++ b/app/controllers/Accounts.scala
@@ -73,7 +73,7 @@ object Accounts extends Controller with stack.APIAuthElement {
         Status(CREATED)(
           FunnelResponse(CREATED, """New password token generated successfully.
             |
-            |You can use the the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
+            |You can use the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
       case Failure(err) =>
         val rn: FunnelResponse = new HttpReturningError(err)
         Status(rn.code)(rn.toJson(true))
@@ -85,9 +85,9 @@ object Accounts extends Controller with stack.APIAuthElement {
     models.base.Accounts.repassword(input) match {
       case Success(succ) =>
         Status(CREATED)(
-          FunnelResponse(CREATED, """Account reseted successfully.
+          FunnelResponse(CREATED, """Account reset successfully.
             |
-            |You can use the the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
+            |You can use the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
       case Failure(err) =>
         val rn: FunnelResponse = new HttpReturningError(err)
         Status(rn.code)(rn.toJson(true))
@@ -106,7 +106,7 @@ object Accounts extends Controller with stack.APIAuthElement {
               Status(CREATED)(
                 FunnelResponse(CREATED, """Account updated successfully.
             |
-            |You can use the the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
+            |You can use the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/camp/Assemblies.scala
+++ b/app/controllers/camp/Assemblies.scala
@@ -40,10 +40,11 @@ object Assemblies extends Controller with controllers.stack.APIAuthElement {
           val clientAPIBody = freq.clientAPIBody.getOrElse(throw new Error("Body not found (or) invalid."))
           models.tosca.Assemblies.create(apiAccessed, clientAPIBody) match {
             case Success(wrapasm) =>
-              Status(CREATED)(FunnelResponse(CREATED, """Submitted successfully.
-            |
-            |
-            |Our engine is cranking up.""", "Megam::Assemblies").toJson(true))
+              Status(CREATED)(
+                FunnelResponse(CREATED, """{%s} submitted successfully.
+              |
+              |Check the status of the launch for the progress.""".format(wrapasm.id), "Megam::Assemblies").toJson(true)
+            )          
             case Failure(err) => {
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))


### PR DESCRIPTION
Parse the content in `{ASM744...}` and show it as **predeploying** or **vm/app management**

```
"code":201,
App 11261 stdout:   "msg_type":"info",
App 11261 stdout:   "msg":"**{AMS7449548610012404513}** submitted successfully.\n              |\n              |Check the status of the launch for the progress.",
App 11261 stdout:   "more":"",
App 11261 stdout:   "json_claz":"Megam::Assemblies",
App 11261 stdout:   "links":"Forum   :http://docs.megam.io/discuss\nDocs    :http://docs.megam.io\nSupport :http://support.megam.io"
```
