### PR TITLE
Updated reset password with the new pkbd12

### DIFF
--- a/app/MConfig.scala
+++ b/app/MConfig.scala
@@ -7,6 +7,7 @@ package app
 object MConfig {
   val nsqurl = play.api.Play.application(play.api.Play.current).configuration.getString("nsq.url").get
   val mute_events = play.api.Play.application(play.api.Play.current).configuration.getBoolean("nsq.events.muted").get
+  val mute_emails = play.api.Play.application(play.api.Play.current).configuration.getStringList("nsq.events.muted_emails").get
 
   val scyllaurl = play.api.Play.application(play.api.Play.current).configuration.getString("scylla.host").get
   val scylla_keyspace = play.api.Play.application(play.api.Play.current).configuration.getString("scylla.keyspace").get

--- a/app/cache/InMemoryCache.scala
+++ b/app/cache/InMemoryCache.scala
@@ -26,7 +26,7 @@ case class InMemoryCache[A]() {
     new InMemoryCache[A]
   }
   def getAs(c: String): Option[Timestamped[A]] = {
-    play.api.Logger.debug("%-20s -->[%s]".format("InMemoryCache:", "getAs ?" + c))
+    play.api.Logger.debug("%-20s -->[%s]".format("MEMCACHE:", "getAs ?" + c))
     play.api.cache.Cache.getAs[Timestamped[A]](c)
   }
 }
@@ -65,7 +65,6 @@ class InMemoryImpl[A](f: String => A)(implicit sedv: Sedimenter[A]) extends InMe
    */
   private def checkMem(u: String)(implicit sed: Sedimenter[A]): StateCacheO[A] = for {
     ofs <- State.gets { c: InMemoryCache[A] =>
-      play.api.Logger.debug("%-20s -->[%s]".format("|^/^|-->checkMem:", u))
       c.getAs(u).collect {
         case Timestamped(fs, ts) if (sed.sediment(fs) && !stale(ts)) => fs
       }
@@ -78,7 +77,7 @@ class InMemoryImpl[A](f: String => A)(implicit sedv: Sedimenter[A]) extends InMe
    * probably control it using  a key
    */
   private def stale(ts: Long): Boolean = {
-    val sweetPieTime = if (play.api.Play.application(play.api.Play.current).mode == play.api.Mode.Dev) (5 * 60 * 100L) else (5 * 60 * 1000L)
+    val sweetPieTime = if (play.api.Play.application(play.api.Play.current).mode == play.api.Mode.Dev) (1L) else (1L)
     System.currentTimeMillis - ts > sweetPieTime
   }
 
@@ -92,7 +91,6 @@ class InMemoryImpl[A](f: String => A)(implicit sedv: Sedimenter[A]) extends InMe
     tfs = Timestamped(fs, System.currentTimeMillis)
     _ <- State.modify[S[A]] { _.update(u, tfs) }
   } yield {
-    play.api.Logger.debug("%-20s -->[%s]".format("\\_/-->retrieve:", u));
     fs
   }
 

--- a/app/controllers/Accounts.scala
+++ b/app/controllers/Accounts.scala
@@ -73,9 +73,7 @@ object Accounts extends Controller with stack.APIAuthElement {
     models.base.Accounts.forgot(id) match {
       case Success(succ) =>
         Status(CREATED)(
-          FunnelResponse(CREATED, """Passwork ticket generated successfully.
-            |
-            |You can use the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
+          FunnelResponse(CREATED, "Password token generated successfully.", "Megam::Account").toJson(true))
       case Failure(err) =>
         val rn: FunnelResponse = new HttpReturningError(err)
         Status(rn.code)(rn.toJson(true))
@@ -87,9 +85,7 @@ object Accounts extends Controller with stack.APIAuthElement {
     models.base.Accounts.password_reset(input) match {
       case Success(succ) =>
         Status(CREATED)(
-          FunnelResponse(CREATED, """Password reset successfully.
-            |
-            |You can use the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
+          FunnelResponse(CREATED, "Password reset successfully.", "Megam::Account").toJson(true))
       case Failure(err) =>
         val rn: FunnelResponse = new HttpReturningError(err)
         Status(rn.code)(rn.toJson(true))
@@ -106,9 +102,7 @@ object Accounts extends Controller with stack.APIAuthElement {
           models.base.Accounts.update(email, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Account updated successfully.
-            |
-            |You can use the 'Accounts':{%s}.""".format(succ.getOrElse("none")), "Megam::Account").toJson(true))
+                FunnelResponse(CREATED, "Your profile updated successfully.", "Megam::Account").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/Constants.scala
+++ b/app/controllers/Constants.scala
@@ -21,34 +21,7 @@ object Constants {
 
   val MEGAM_HOME = sys.env.get("MEGAM_HOME").getOrElse("/var/lib/megam") //THIS
 
-  val TEST_EMAIL = "test@megam.io"
-  val TEST_APIKEY = "IamAtlas{74}NobdyCanSedfefdeME#07"
-  val TEST_PASSWORD = "$2a$10$ebE.KJITo19bkJ/s8gMFpuXkMh2Tu5vL4eVcgJN7THYD1/zjcmxq3"
-  val MEGAM_TEST_FIRST_NAME = "Megam Test"
-
-  val DEMO_EMAIL = "tour@megam.io"
-  val DEMO_APIKEY = "faketour"
-  val MEGAM_FIRST_NAME = "Vertis Tour"
-  val MEGAM_LAST_NAME = "Call us"
-  val MEGAM_PHONE = "18006186813"
-  val MEGAM_PHONE_VERIFIED = "verified"
-  val MEGAM_ACTIVE = "active"
-  val MEGAM_BLOCKED = "blocked"
-  val MEGAM_APPROVED = "approved"
-  val MEGAM_APPROVED_BY_ID ="nil"
-  val MEGAM_APPROVED_AT = "nil"
-  val MEGAM_LAST_POSTED_AT ="nil"
-  val MEGAM_LAST_EMAILED_AT = "nil"
-  val MEGAM_PREVIOUS_VISIT_AT = "nil"
-  val MEGAM_FIRST_SEEN_AT = "nil"
-  val MEGAM_SUSPENDED = "suspend"
-  val MEGAM_SUSPENDED_AT = "nil"
-  val MEGAM_SUSPENDED_TILL = "nil"
-  val MEGAM_REGISTRATION_IP_ADDRESS = "nil"
-  val SAMPLE_PASSWORD = "$2a$10$ebE.KJITo19bkJ/s8gMFpuXkMh2Tu5vL4eVcgJN7THYD1/YiBNWP2"
-  val MEGAM_PASSWORD_RESET_KEY = "nil"
-  val MEGAM_PASSWORD_RESET_SENT_AT = "nil"
-
   val MEGAM_ADMIN_AUTHORITY = "admin"
+  
   val MEGAM_NORMAL_AUTHORITY = "normal"
 }

--- a/app/controllers/Requests.scala
+++ b/app/controllers/Requests.scala
@@ -21,9 +21,7 @@ object Requests extends Controller with controllers.stack.APIAuthElement {
           val clientAPIBody = freq.clientAPIBody.getOrElse(throw new Error("Body not found (or) invalid."))
           models.base.Requests.createAndPub(email, clientAPIBody) match {
             case Success(succ) =>
-                Status(CREATED)(FunnelResponse(CREATED, """Request initiation instruction submitted successfully.
-                 |
-                 |Check on the overview for updates. It will be ready shortly.""", "Megam::Request").toJson(true))
+                Status(CREATED)(FunnelResponse(CREATED, "Request submitted successfully.", "Megam::Request").toJson(true))
             case Failure(err) => {
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/SshKeys.scala
+++ b/app/controllers/SshKeys.scala
@@ -24,7 +24,7 @@ object SshKeys extends Controller with controllers.stack.APIAuthElement {
           models.base.SshKeys.create(apiAccessed, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """SshKeys created successfully.""", "Megam::SshKey").toJson(true))
+                FunnelResponse(CREATED, """SSHKey created successfully.""", "Megam::SshKey").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/billing/Balances.scala
+++ b/app/controllers/billing/Balances.scala
@@ -32,9 +32,7 @@ object Balances extends Controller with controllers.stack.APIAuthElement {
           models.billing.Balances.create(email, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Balances created successfully.
-            |
-            |You can use the the 'Balances':{%s}.""".format(succ.getOrElse("none")), "Megam::Balances").toJson(true))
+                FunnelResponse(CREATED, "Your balance created successfully.", "Megam::Balances").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))
@@ -58,9 +56,7 @@ object Balances extends Controller with controllers.stack.APIAuthElement {
           models.billing.Balances.update(email, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Balances updated successfully.
-            |
-            |You can use the the 'Balances'.""", "Megam::Balances").toJson(true))
+                FunnelResponse(CREATED, "Your balances updated successfully.", "Megam::Balances").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/billing/Billedhistories.scala
+++ b/app/controllers/billing/Billedhistories.scala
@@ -34,9 +34,7 @@ implicit val formats = DefaultFormats
           models.billing.Billedhistories.create(email, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Billedhistories created successfully.
-            |
-            |You can use the the 'Billedhistoriess':{%s}.""".format(succ.getOrElse("none")), "Megam::Billedhistories").toJson(true))
+                FunnelResponse(CREATED, "Billing history record created successfully.", "Megam::Billedhistories").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/billing/Billingtranscations.scala
+++ b/app/controllers/billing/Billingtranscations.scala
@@ -33,9 +33,7 @@ implicit val formats = DefaultFormats
           models.billing.Billingtranscations.create(email, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Billingtranscations created successfully.
-            |
-            |You can use the the 'Billingtranscations':{%s}.""".format(succ.getOrElse("none")), "Megam::Billingtranscations").toJson(true))
+                FunnelResponse(CREATED, "Billingtransactions record created successfully."  , "Megam::Billingtranscations").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/billing/Subscriptions.scala
+++ b/app/controllers/billing/Subscriptions.scala
@@ -34,9 +34,7 @@ implicit val formats = DefaultFormats
           models.billing.Subscriptions.create(email, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Subscriptions created successfully.
-            |
-            |You can use the the 'Subscriptions':{%s}.""".format(succ.getOrElse("none")), "Megam::Subscriptions").toJson(true))
+                FunnelResponse(CREATED, "Your subscriptions created successfully.", "Megam::Subscriptions").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/camp/Assemblies.scala
+++ b/app/controllers/camp/Assemblies.scala
@@ -26,9 +26,7 @@ object Assemblies extends Controller with controllers.stack.APIAuthElement {
           models.tosca.Assemblies.create(apiAccessed, clientAPIBody) match {
             case Success(wrapasm) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """[%s,%s] submitted successfully.
-              |
-              |Check the status of the launch for the progress.""".format(wrapasm.assemblies.mkString("|"),wrapasm.id), "Megam::Assemblies").toJson(true)
+                FunnelResponse(CREATED, """[%s,%s] deployment submitted successfully.""".format(wrapasm.assemblies.mkString("|"),wrapasm.id), "Megam::Assemblies").toJson(true)
             )
             case Failure(err) => {
               val rn: FunnelResponse = new HttpReturningError(err)
@@ -53,7 +51,7 @@ object Assemblies extends Controller with controllers.stack.APIAuthElement {
     (Validation.fromTryCatchThrowable[Result, Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Assemblies wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           models.tosca.Assemblies.findById(List(id).some) match {
             case Success(succ) =>
@@ -81,7 +79,7 @@ object Assemblies extends Controller with controllers.stack.APIAuthElement {
     (Validation.fromTryCatchThrowable[Result, Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Assemblies wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           val org = freq.maybeOrg.getOrElse(throw new Error("Org not found (or) invalid."))
           models.tosca.Assemblies.findByEmail(email, org) match {

--- a/app/controllers/camp/Assembly.scala
+++ b/app/controllers/camp/Assembly.scala
@@ -42,15 +42,13 @@ object Assembly extends Controller with controllers.stack.APIAuthElement {
     (Validation.fromTryCatchThrowable[Result, Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Assemblies wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           val clientAPIBody = freq.clientAPIBody.getOrElse(throw new Error("Body not found (or) invalid."))
           val org = freq.maybeOrg.getOrElse(throw new Error("Org not found (or) invalid."))
           models.tosca.Assembly.update(org, clientAPIBody) match {
             case Success(succ) => {
-              Status(CREATED)(FunnelResponse(CREATED, """Bind initiation submitted successfully.
-            |
-            |Engine is cranking.""", "Megam::Assembly").toJson(true))
+              Status(CREATED)(FunnelResponse(CREATED, "Deployment update submitted successfully.", "Megam::Assembly").toJson(true))
             }
             case Failure(err) => {
               val rn: FunnelResponse = new HttpReturningError(err)
@@ -70,9 +68,7 @@ object Assembly extends Controller with controllers.stack.APIAuthElement {
   def upgrade(id: String) = Action(parse.tolerantText) { implicit request =>
     models.tosca.Assembly.upgrade("", id) match {
       case Success(succ) => {
-        Status(CREATED)(FunnelResponse(CREATED, """Your upgrade is in process.
-            |
-            |Engine is cranking.""", "Megam::Assembly").toJson(true))
+        Status(CREATED)(FunnelResponse(CREATED, "Deployment upgrade submitted successfully", "Megam::Assembly").toJson(true))
       }
       case Failure(err) => {
         val rn: FunnelResponse = new HttpReturningError(err)

--- a/app/controllers/snapshots/Snapshots.scala
+++ b/app/controllers/snapshots/Snapshots.scala
@@ -24,7 +24,7 @@ def post = StackAction(parse.tolerantText) { implicit request =>
         models.snapshots.Snapshots.create(email, clientAPIBody) match {
           case Success(succ) =>
             Status(CREATED)(
-              FunnelResponse(CREATED, """Snapshots created successfully.""", "Megam::Snapshots").toJson(true))
+              FunnelResponse(CREATED, "Snapshot created successfully.", "Megam::Snapshots").toJson(true))
           case Failure(err) =>
             val rn: FunnelResponse = new HttpReturningError(err)
             Status(rn.code)(rn.toJson(true))

--- a/app/controllers/team/Domains.scala
+++ b/app/controllers/team/Domains.scala
@@ -22,20 +22,17 @@ object  Domains extends Controller with controllers.stack.APIAuthElement {
    * Old value for the same key gets wiped out.
    */
   def post = StackAction(parse.tolerantText) { implicit request =>
-    play.api.Logger.debug(("%-20s -->[%s]").format("camp.Domains", "post:Entry"))
-
     (Validation.fromTryCatchThrowable[Result,Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Request wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           val clientAPIBody = freq.clientAPIBody.getOrElse(throw new Error("Body not found (or) invalid."))
           val org = freq.maybeOrg.getOrElse(throw new Error("Org not found (or) invalid."))
-          play.api.Logger.debug(("%-20s -->[%s]").format("camp.Domains", "request funneled."))
           models.team.Domains.create(org, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Domains created successfully.""", "Megam::Domains").toJson(true))
+                FunnelResponse(CREATED, "Domain created successfully.", "Megam::Domains").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))
@@ -56,17 +53,12 @@ object  Domains extends Controller with controllers.stack.APIAuthElement {
    * Output: JSON (DomainsResult)
    **/
   def list = StackAction(parse.tolerantText) { implicit request =>
-    play.api.Logger.debug(("%-20s -->[%s]").format("camp.Domains", "show:Entry"))
-    play.api.Logger.debug(("%-20s -->[%s]").format("name", id))
-
-    (Validation.fromTryCatchThrowable[Result,Throwable] {
+      (Validation.fromTryCatchThrowable[Result,Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Request wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           val org = freq.maybeOrg.getOrElse(throw new Error("Org not found (or) invalid."))
-
-          play.api.Logger.debug(("%-20s -->[%s]").format("camp.Domains", "request funneled."))
 
           models.team.Domains.findByOrgId(apiAccessed) match {
             case Success(succ) =>

--- a/app/controllers/team/Organizations.scala
+++ b/app/controllers/team/Organizations.scala
@@ -25,13 +25,13 @@ object Organizations extends Controller with controllers.stack.APIAuthElement {
     (Validation.fromTryCatchThrowable[Result,Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Request wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           val clientAPIBody = freq.clientAPIBody.getOrElse(throw new Error("Body not found (or) invalid."))
           models.team.Organizations.create(email, clientAPIBody) match {
             case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """Organizations created successfully""", "Megam::Organizations").toJson(true))
+                FunnelResponse(CREATED, "Organization created successfully", "Megam::Organizations").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))
@@ -55,7 +55,7 @@ object Organizations extends Controller with controllers.stack.APIAuthElement {
     (Validation.fromTryCatchThrowable[Result,Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Request wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           models.team.Organizations.findByEmail(email) match {
             case Success(succ) => {
@@ -84,13 +84,13 @@ object Organizations extends Controller with controllers.stack.APIAuthElement {
     (Validation.fromTryCatchThrowable[Result,Throwable] {
       reqFunneled match {
         case Success(succ) => {
-          val freq = succ.getOrElse(throw new Error("Organizations wasn't funneled. Verify the header."))
+          val freq = succ.getOrElse(throw new Error("Invalid header."))
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
           val clientAPIBody = freq.clientAPIBody.getOrElse(throw new Error("Body not found (or) invalid."))
           models.team.Organizations.inviteOrganization(email, clientAPIBody) match {
            case Success(succ) =>
               Status(CREATED)(
-                FunnelResponse(CREATED, """User added into Organization successfully""" , "Megam::Organizations").toJson(true))
+                FunnelResponse(CREATED, "We invited into your organization successfully" , "Megam::Organizations").toJson(true))
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/models/base/Events.scala
+++ b/app/models/base/Events.scala
@@ -56,7 +56,7 @@ class Events(evi: EventInput) {
     (create() leftMap { err: NonEmptyList[Throwable] =>
       err
     }).flatMap { pq: Option[wash.PQd] =>
-      if (!evi.email.equalsIgnoreCase(controllers.Constants.DEMO_EMAIL) && 
+      if (!MConfig.mute_emails.contains(evi.email) && 
           !MConfig.mute_events) {
         (new wash.AOneWasher(pq.get).wash).
           flatMap { maybeGS: AMQPResponse =>

--- a/app/models/base/Requests.scala
+++ b/app/models/base/Requests.scala
@@ -152,7 +152,7 @@ object Requests extends ConcreteRequests {
     (create(input) leftMap { err: NonEmptyList[Throwable] =>
       err
     }).flatMap { pq: Option[wash.PQd] =>
-      if (!email.equalsIgnoreCase(controllers.Constants.DEMO_EMAIL)) {
+      if (!MConfig.mute_emails.contains(email)) {
         new wash.AOneWasher(pq.get).wash flatMap { maybeGS: AMQPResponse =>
           play.api.Logger.debug(("%-20s -->[%s]").format("Request.published successfully", input))
           pq.successNel[Throwable]

--- a/app/wash/AOneWasher.scala
+++ b/app/wash/AOneWasher.scala
@@ -22,7 +22,6 @@ case class AOneWasher(pq: models.Messageble) extends MessageContext {
   val msg = pq.messages
 
   def wash(): ValidationNel[Throwable, AMQPResponse] = {
-    play.api.Logger.debug("%-20s -->[%s]".format("Washing:[" + topic + "]", msg))
     execute(nsqClient.publish(msg))
   }
 }

--- a/conf/gateway.conf
+++ b/conf/gateway.conf
@@ -29,6 +29,7 @@ nsq.url="http://localhost:4151"
 nsq.topic.vms="vms"
 nsq.topic.containers="containers"
 nsq.events.muted = false
+nsq.events.muted_emails = ["tour@megam.io"]
 
 # Org/Domain and general
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I finally found the culprit, i wrote a cache last summer based on `State Monad` which decided to cache **Account Information** in **memory for a `x` amount of time. 

And i don't remember what to tweak in the `StateMonad`. I had a **sedimenter** to decide to cache or not. 

The problem is when we update the password, the cache stays stale and hence even though the update is successful for passwords/api_key, we still use the stale cache for 10 mins.

I have reduced the  cache  timing to 1s. 

Eitherway we'll use the new  `rust-lang` code in 2.0.
