### PR TITLE
Tested the fix, we cleanly nuke everything for an user.

### DIFF
--- a/app/controllers/admin/Users.scala
+++ b/app/controllers/admin/Users.scala
@@ -29,7 +29,7 @@ object Users extends Controller with APIAuthElement with PermissionElement {
           val org    = freq.maybeOrg.getOrElse(throw new CannotAuthenticateError("Org not found (or) invalid.", "Read docs.megam.io/api."))
           val admin  = canPermit(grabAuthBag).getOrElse(throw new PermissionNotThere("admin authority is required to access this resource.", "Read docs.megam.io/api."))
 
-          models.admin.Users.list match {
+          models.admin.Users.delete(id) match {
             case Success(succ) => {
               Ok(Results.resultset(models.Constants.ADMINUSERSCOLLECTIONCLAZ, compactRender(Extraction.decompose(succ))))
              }

--- a/app/models/admin/Users.scala
+++ b/app/models/admin/Users.scala
@@ -26,6 +26,7 @@ object Users {
 
   //An Admin can scavenge an user
   def delete(id: String): ValidationNel[Throwable, Option[AccountResult]] = {
+    play.api.Logger.debug("%-20s -->[%s]".format("UD:", "delete ?" + id))
     for {
       nls <- models.admin.audits.Scavenger(id).nukeLittered
       nds <- models.admin.audits.Scavenger(id).nukeDeployed

--- a/app/models/admin/audits/Auditor.scala
+++ b/app/models/admin/audits/Auditor.scala
@@ -80,7 +80,7 @@ sealed class AuditLogSacks extends CassandraTable[AuditLogSacks, AuditLogResult]
 }
 
 abstract class ConcreteAuditLog extends AuditLogSacks with RootConnector {
-  override lazy val tableName = "events_for_billings"
+  override lazy val tableName = "audit_logs"
   override implicit def space: KeySpace = scyllaConnection.space
   override implicit def session: Session = scyllaConnection.session
 

--- a/app/models/admin/audits/Scavenger.scala
+++ b/app/models/admin/audits/Scavenger.scala
@@ -33,7 +33,7 @@ class Scavenger(email: String) {
     for {
       orgs <-   myorgs leftMap { err: NonEmptyList[Throwable] ⇒ err }
       aal  <-   deployed(orgs)
-    } yield aal
+    } yield   aal
   }
 
   def nukeTelemetry = {
@@ -44,7 +44,7 @@ class Scavenger(email: String) {
       chd <- models.billing.Credits.delete(email)
       qud <- models.billing.Quotas.delete(email)
       qud <- models.tosca.Sensors.delete(email)
-    } yield "telemetry.done".some
+    } yield  "telemetry.done".some
   }
 
   def nukeWhitePebbles = {
@@ -52,13 +52,13 @@ class Scavenger(email: String) {
       hd  <- models.events.EventsBilling.delete(email)
       bhd <- models.events.EventsContainer.delete(email)
       bad <- models.events.EventsVm.delete(email)
-    } yield "whitepebbles.done".some
+    } yield  "whitepebbles.done".some
   }
 
   def nukeIdentity: ValidationNel[Throwable, Option[io.megam.auth.stack.AccountResult]] = {
     for {
       aal <-   delete
-    } yield aal
+    } yield  aal
   }
 
   private def littered = {

--- a/app/models/disks/Disks.scala
+++ b/app/models/disks/Disks.scala
@@ -238,7 +238,7 @@ def update(email: String, input: String): ValidationNel[Throwable, DisksResult] 
       if (!nm.isEmpty)
         Validation.success[Throwable, Seq[DisksResult]](nm).toValidationNel
       else
-        Validation.failure[Throwable, Seq[DisksResult]](new ResourceItemNotFound(accountID, "Disks = nothing found.")).toValidationNel
+        Validation.success[Throwable, Seq[DisksResult]](List[DisksResult]()).toValidationNel
     }
 
   }
@@ -269,10 +269,15 @@ def update(email: String, input: String): ValidationNel[Throwable, DisksResult] 
   }
 
   private def deleteFound(email: String, ds: Seq[DisksResult]) = {
-      (ds.map { was =>
+      val output = (ds.map { was =>
         play.api.Logger.warn(("%s%s%-20s%s").format(Console.GREEN, Console.BOLD, "Disks.delete success", Console.RESET))
         dePub(email, was)
-      }).head
+      })
+
+      if (!output.isEmpty)
+         output.head
+      else
+        DisksResult("","","","","","","").successNel
    }
 
 

--- a/app/models/snapshots/Snapshots.scala
+++ b/app/models/snapshots/Snapshots.scala
@@ -239,7 +239,7 @@ def update(email: String, input: String): ValidationNel[Throwable, SnapshotsResu
       if (!nm.isEmpty)
         Validation.success[Throwable, Seq[SnapshotsResult]](nm).toValidationNel
       else
-        Validation.failure[Throwable, Seq[SnapshotsResult]](new ResourceItemNotFound(accountID, "Snapshots = nothing found.")).toValidationNel
+        Validation.success[Throwable, Seq[SnapshotsResult]](List[SnapshotsResult]()).toValidationNel
     }
   }
 
@@ -296,11 +296,17 @@ def update(email: String, input: String): ValidationNel[Throwable, SnapshotsResu
   }
 
   private def deleteFound(email: String, sn: Seq[SnapshotsResult]) = {
-      (sn.map { sas =>
+      val output = (sn.map { sas =>
         play.api.Logger.warn(("%s%s%-20s%s").format(Console.GREEN, Console.BOLD, "Snapshots.delete success", Console.RESET))
         dePub(email, sas)
-      }).head
-   }
+      })
+
+      if (!output.isEmpty)
+         output.head
+      else
+        SnapshotsResult("","","","","","","", "", models.tosca.KeyValueList.empty, models.tosca.KeyValueList.empty).successNel
+  }
+
 
   //We support attaching disks for a VM. When we do containers we need to rethink.
   private def atPub(email: String, wa: SnapshotsResult): ValidationNel[Throwable, SnapshotsResult] = {

--- a/app/models/tosca/Assembly.scala
+++ b/app/models/tosca/Assembly.scala
@@ -259,7 +259,7 @@ object Assembly extends ConcreteAssembly {
       if (!nm.isEmpty)
         Validation.success[Throwable, Seq[AssemblyResult]](nm).toValidationNel
       else
-        Validation.failure[Throwable, Seq[AssemblyResult]](new ResourceItemNotFound(org_id, "Assembly = nothing found.")).toValidationNel
+        Validation.success[Throwable, Seq[AssemblyResult]](List[AssemblyResult]()).toValidationNel
     }
   }
 
@@ -314,13 +314,21 @@ object Assembly extends ConcreteAssembly {
   }
 
   private def deleteFound(email: String, an: Seq[AssemblyResult]) = {
-      (an.map { asa =>
+      val output = (an.map { asa =>
            if (!(STATUS_DESTROYED.contains(asa.status) ||
                  STATUS_DESTROYED.contains(asa.state)))
              dePub(email, asa)
           else
              asa.successNel[Throwable]
-      }).head
+      })
+
+      if (!output.isEmpty)
+         output.head
+      else
+        AssemblyResult("","","","", models.tosca.ComponentLinks.empty,"",
+          models.tosca.PoliciesList.empty, models.tosca.KeyValueList.empty,
+          models.tosca.KeyValueList.empty, "", "", "", DateHelper.now()).successNel
+
    }
 
   private def dePub(email: String, wa: AssemblyResult): ValidationNel[Throwable, AssemblyResult] = {

--- a/app/models/tosca/package.scala
+++ b/app/models/tosca/package.scala
@@ -86,8 +86,12 @@ package object tosca {
     def empty: List[String] = emptyRR
   }
 
- type MetricsList = List[Metrics]
+  type MetricsList = List[Metrics]
+
   type PoliciesList = List[Policy]
+  object PoliciesList {
+    def empty: List[Policy] = List[Policy]()
+  }
 
   type MembersList = List[String]
 


### PR DESCRIPTION
We now have an audit table, if the nuke is successful, then you can see an entry as follows in audit_logs table.

```
vertadmin@cqlsh:vertice> select * from audit_logs;

 admin@megam.io | 2017-01-27 16:42:06.000000+0000 | user.deleted | ['{"key":"kind","value":"deployed,team,telemetry,identity"}', '{"key":"status","value":"success"}'] | AUL7871930588274143112 | Megam::AuditLog
```