### PR TITLE
Multiple recurring products can be paid and launched

### DIFF
--- a/app/models/Constants.scala
+++ b/app/models/Constants.scala
@@ -41,7 +41,7 @@ object Constants {
   val ANALYTICS         = "analytics"
   val COLLABORATION     = "collaboration"
 
-  val STATUS_DESTROYED            = List("destroyed", "preerror")
+  val STATUS_DESTROYED                    = List("destroyed", "preerror")
 
   val REPORT_SALES                        = "sales"
   val REPORT_USRDOT                       = "userdot"

--- a/app/models/tosca/UnitsBreaker.scala
+++ b/app/models/tosca/UnitsBreaker.scala
@@ -25,7 +25,7 @@ class UnitsBreaker(input: String) {
 
   implicit val formats = DefaultFormats
 
-  private def toObject: ValidationNel[Throwable, AssembliesInput] = {
+  private lazy val toObject: ValidationNel[Throwable, AssembliesInput] = {
     val aio: ValidationNel[Throwable, AssembliesInput] = (Validation.fromTryCatchThrowable[AssembliesInput, Throwable] {
       parse(input).extract[AssembliesInput]
     } leftMap { t: Throwable => new MalformedBodyError(input, t.getMessage) }).toValidationNel
@@ -37,9 +37,11 @@ class UnitsBreaker(input: String) {
     }
   }
 
+
   private def till = toObject.map(_.number_of_units).getOrElse(0)
 
   private def uno  = (till == 1)
+
 
   //if its a uno (single launch, then return and use the name)
   private def nameOfUnit(i: Int, n: String): String = {
@@ -59,9 +61,36 @@ class UnitsBreaker(input: String) {
     for {
       too <- toObject
     } yield {
-      val changed = too.assemblies.map(ai => Assembly(nameOfUnit(i, ai.name), ai.components, ai.tosca_type,
-                                        ai.policies, ai.inputs, ai.outputs, ai.status, ai.state))
+        val changed = too.assemblies.map { ai =>
+        val decompkvs = FieldSplitter(till, KeyValueField("quota_ids", "quota_id"), ai.inputs).merged
+        Assembly(nameOfUnit(i, ai.name), ai.components, ai.tosca_type,
+                                        ai.policies, decompkvs.get(i).get, ai.outputs, ai.status, ai.state)
+        }
+
       List(AssembliesInput(too.name, too.org_id, changed, too.inputs))
     }
   }
+}
+
+case class FieldSplitter(nos: Int, field: KeyValueField, kvs: KeyValueList) {
+
+  val VALUE_KEY = field.value
+
+  val FILTER_KEY = field.key
+
+  val COMMA = ","
+
+  val filter = KeyValueList.filter(kvs, FILTER_KEY)
+
+  val filterNot = KeyValueList.filterNot(kvs, FILTER_KEY)
+
+  val split  = (filter.map { x => x.value.split(COMMA).map(KeyValueField(VALUE_KEY, _)).toList }).flatten.zipWithIndex.map(x => List(x._1))
+
+  val merged: Map[Int, KeyValueList] = ({
+    if (split.isEmpty) {
+      ((1 to nos).toList.map((_, filterNot)))
+    } else {
+       ((1 to nos).toList.zip(split.map(_  ++ filterNot)))
+     }
+  }).toMap
 }

--- a/app/models/tosca/package.scala
+++ b/app/models/tosca/package.scala
@@ -159,6 +159,14 @@ package object tosca {
       nrec
     }
 
+    def filter(nres: KeyValueList, key: String): KeyValueList = {
+       nres.filter(x => x.key.equalsIgnoreCase(key) && x.value.trim.length > 0)
+    }
+
+    def filterNot(nres: KeyValueList, key: String): KeyValueList = {
+       nres.filterNot(_.key.equalsIgnoreCase(key))
+    }
+
     def apply(m: Map[String, String]): KeyValueList = m.toList.map { x => KeyValueField(x._1, x._2) }
 
     def apply(plansList: List[KeyValueField]): KeyValueList = plansList


### PR DESCRIPTION
Multiple products (quota) of the same kind can be paid and launched. 

@vinomca-megam  Test the quota side of it. 
I unit tested it using `scala console`,

May be we can test it along with the other changes for the 1.5.1 fixpack due this week.