### PR TITLE
Rawimage didn't pull the date correctly is fixed. Guys test our 1.5.2 custom image (ISO  feature)

### DIFF
--- a/app/controllers/billing/Quotas.scala
+++ b/app/controllers/billing/Quotas.scala
@@ -84,12 +84,8 @@ object Quotas extends Controller with APIAuthElement  {
           val email = freq.maybeEmail.getOrElse(throw new Error("Email not found (or) invalid."))
 
           models.billing.Quotas.findById(id) match {
-            case Success(succ) => {
-            play.api.Logger.info(("%s%s%-20s%s").format(Console.CYAN, Console.BOLD, "=>" +succ  ,Console.RESET))
-            play.api.Logger.info(("%s%s%-20s%s").format(Console.BLUE, Console.BOLD, "=>" + Extraction.decompose(succ),Console.RESET))
-
+            case Success(succ) =>
             Ok(Results.resultset(models.Constants.QUOTASCOLLECTIONCLAZ, compactRender(Extraction.decompose(succ))))
-          }
             case Failure(err) =>
               val rn: FunnelResponse = new HttpReturningError(err)
               Status(rn.code)(rn.toJson(true))

--- a/app/controllers/disks/RawImages.scala
+++ b/app/controllers/disks/RawImages.scala
@@ -6,17 +6,17 @@ import scalaz.Validation
 import scalaz.Validation.FlatMap._
 import scalaz.NonEmptyList._
 import net.liftweb.json._
-import net.liftweb.json.JsonParser._
+import controllers.stack.Results
+import controllers.stack.{APIAuthElement, PermissionElement}
 
+import models.disks._
 import io.megam.auth.funnel.{ FunnelResponse, FunnelResponses }
 import io.megam.auth.funnel.FunnelErrors._
 import io.megam.auth.stack.Role._
 
-
 import play.api.mvc._
-import models.billing._
-import controllers.stack.Results
-import controllers.stack.{APIAuthElement, PermissionElement}
+
+
 
 /**
  * @author rajthilak

--- a/app/controllers/stack/ImplicitJsonFormats.scala
+++ b/app/controllers/stack/ImplicitJsonFormats.scala
@@ -6,7 +6,7 @@ import java.text.SimpleDateFormat
 
 trait ImplicitJsonFormats {
 
-    private val default: DefaultFormats with Object {def dateFormatter: SimpleDateFormat} = new DefaultFormats {
+    val default: DefaultFormats with Object {def dateFormatter: SimpleDateFormat} = new DefaultFormats {
         override def dateFormatter = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS")
     }
 

--- a/app/controllers/stack/Results.scala
+++ b/app/controllers/stack/Results.scala
@@ -28,6 +28,7 @@ object Results {
 
  def resultset(jsonclaz: String, result: String): String = {
     val res = JsonParser.parse(result)
+
     prettyRender(JObject(JField(JSONClazKey, JString(jsonclaz)) :: JField(ResultsKey, res) :: Nil))
   }
 

--- a/app/models/disks/package.scala
+++ b/app/models/disks/package.scala
@@ -21,7 +21,7 @@ package object disks {
   object DiskResults {
     val emptyNR = List(Option.empty[DisksResult])
     def apply(m: Option[DisksResult]) = List(m)
-    def empty: DisksResults = List() 
+    def empty: DisksResults = List()
   }
 
   type BackupsResults = List[Option[BackupsResult]]


### PR DESCRIPTION
@vinomca-megam @vijaykanthm28 

Lets rock & roll our `Hybrid marketplace feature` via `support for user customized images using ISO mirror`

@rajthilakmca  fyi.

The problem i had was `created_at` class `joda.DateTime` didn't get unmarshalled to a String.

I basically changed the order of imports in `controllers.disks.RawImages` and it worked.  

So basically our `ImplicitJsonFormats`  that supports data marshall/unmarshall is working. There is no doubt about that.


Weird. !

![screenshot from 2017-03-02 22-55-19](https://cloud.githubusercontent.com/assets/1402479/23519252/45a1cd8a-ff9c-11e6-88a8-8148031ed961.png)
